### PR TITLE
EVM proxy connector

### DIFF
--- a/contracts/message-based/ProxyConnector.sol
+++ b/contracts/message-based/ProxyConnector.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.2;
+
+abstract contract ProxyConnector {
+
+  function proxyCalldata(address contractAddress, bytes memory encodedFunction) internal returns (bytes memory) {
+    uint8 dataSize;
+
+    assembly {
+      dataSize := calldataload(sub(calldatasize(), 97))
+    }
+
+    uint16 messageLength = uint16(dataSize) * 64 + 32 + 1 + 65; //datapoints + timestamp + data size + signature
+
+    uint256 encodedFunctionLength = encodedFunction.length;
+
+    uint256 i;
+    bytes memory message;
+
+    assembly {
+      message := mload(0x40)
+
+      mstore(message, add(encodedFunctionLength, messageLength))
+
+      for { i := 0 } lt(i, encodedFunctionLength) { i := add(i, 1) } {
+        mstore(add(add(0x20, message), mul(0x20, i)), mload(add(add(0x20, encodedFunction), mul(0x20, i))))
+      }
+
+      calldatacopy(
+        add(message, add(0x20, encodedFunctionLength)),
+        sub(calldatasize(), messageLength),
+        messageLength
+      )
+
+      mstore(0x40, add(add(message, add(messageLength, encodedFunctionLength)), 0x20))
+    }
+
+    (bool success, bytes memory result) = contractAddress.call(message);
+
+    require(success, 'Proxy connector call failed');
+
+    return result;
+  }
+}

--- a/contracts/samples/SampleInlinedPriceAware.sol
+++ b/contracts/samples/SampleInlinedPriceAware.sol
@@ -13,7 +13,6 @@ import "../message-based/InlinedPriceAware.sol";
  * to reduce the gas of every invocation (saving is ~4k gas)
  */
 contract SampleInlinedPriceAware is InlinedPriceAware {
-  MockStatePriceProvider mockStatePriceProvider = new MockStatePriceProvider();
 
   function getPrice(bytes32 asset) external view returns (uint256) {
     return getPriceFromMsg(asset);

--- a/contracts/samples/SamplePriceAware.sol
+++ b/contracts/samples/SamplePriceAware.sol
@@ -12,7 +12,6 @@ import "../message-based/PriceAware.sol";
  * It extends PriceAware and allows changing trusted signer and message delay
  */
 contract SamplePriceAware is PriceAware {
-  MockStatePriceProvider mockStatePriceProvider = new MockStatePriceProvider();
 
   function getPrice(bytes32 asset) external view returns (uint256) {
     return getPriceFromMsg(asset);
@@ -22,10 +21,25 @@ contract SamplePriceAware is PriceAware {
     return getPriceFromMsg(asset);
   }
 
-  function executeWithPrices(bytes32[] memory assets)
-    public
-    returns (uint256[] memory)
+  function executeWithPrices(bytes32[] memory assets) public returns (uint256[] memory)
   {
     return getPricesFromMsg(assets);
+  }
+
+  //for tests of ProxyConnector
+  function getPriceManyParameters (
+    bytes32 asset,
+    uint256 mockArg1,
+    string memory mockArg2,
+    string memory mockArg3,
+    string memory mockArg4,
+    string memory mockArg5,
+    string memory mockArg6
+  ) external view returns (uint256) {
+    return getPriceFromMsg(asset);
+  }
+
+  function a() external view returns (uint256) {
+    return getPriceFromMsg(bytes32("ETH"));
   }
 }

--- a/contracts/samples/SamplePriceAwareUpgradeable.sol
+++ b/contracts/samples/SamplePriceAwareUpgradeable.sol
@@ -16,7 +16,6 @@ contract SamplePriceAwareUpgradeable is
   OwnableUpgradeable,
   PriceAwareUpgradeable
 {
-  MockStatePriceProvider mockStatePriceProvider = new MockStatePriceProvider();
 
   function initialize() external initializer {
     __Ownable_init();

--- a/contracts/samples/SampleProxyConnector.sol
+++ b/contracts/samples/SampleProxyConnector.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.2;
+
+import "../message-based/ProxyConnector.sol";
+import "./SamplePriceAware.sol";
+import "hardhat/console.sol";
+
+/**
+ * @title ProxyConnector
+ * @dev An example of a contract that makes a call to a PriceAware type contract
+ */
+contract SampleProxyConnector is ProxyConnector {
+
+  SamplePriceAware samplePriceAware;
+
+  function initializePriceAware() external {
+    samplePriceAware = new SamplePriceAware();
+    samplePriceAware.authorizeSigner(0xFE71e9691B9524BC932C23d0EeD5c9CE41161884);
+  }
+
+  function checkPrice(bytes32 asset, uint256 price) external {
+    bytes memory encodedFunction = abi.encodeWithSelector(SamplePriceAware.getPrice.selector, asset);
+
+    bytes memory encodedResult = proxyCalldata(address(samplePriceAware), encodedFunction);
+
+    uint256 oraclePrice = abi.decode(encodedResult, (uint256));
+
+    require(oraclePrice == price, 'Wrong price!');
+  }
+
+  function getPriceShortEncodedFunction
+  (bytes32 asset, uint256 price) external {
+    bytes memory encodedFunction = abi.encodeWithSelector(
+      SamplePriceAware.a.selector
+    );
+
+    bytes memory encodedResult = proxyCalldata(address(samplePriceAware), encodedFunction);
+
+    uint256 oraclePrice = abi.decode(encodedResult, (uint256));
+
+    require(oraclePrice == price, 'Wrong price!');
+  }
+
+  function getPriceLongEncodedFunction(bytes32 asset, uint256 price) external {
+    bytes memory encodedFunction = abi.encodeWithSelector(
+      SamplePriceAware.getPriceManyParameters.selector,
+      asset,
+      115792089237316195423570985008687907853269984665640564039457584007913129639935,
+      'long_string_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'long_string_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'long_string_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'long_string_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'long_string_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      );
+
+    bytes memory encodedResult = proxyCalldata(address(samplePriceAware), encodedFunction);
+
+    uint256 oraclePrice = abi.decode(encodedResult, (uint256));
+
+    require(oraclePrice == price, 'Wrong price!');
+  }
+}

--- a/test/message-based/ProxyConnector.test.ts
+++ b/test/message-based/ProxyConnector.test.ts
@@ -1,0 +1,162 @@
+import {ethers} from "hardhat";
+import {Wallet} from "ethers";
+import chai, {expect} from "chai";
+import {solidity} from "ethereum-waffle";
+import {SampleProxyConnector} from "../../typechain/SampleProxyConnector";
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
+import {syncTime, toBytes32} from "../_helpers";
+import {MockPriceFeed} from "../../utils/v2/connector/impl/MockPriceFeed";
+import {WrapperBuilder} from "../../index";
+
+chai.use(solidity);
+
+
+describe("Proxy Connector", function () {
+    let owner:SignerWithAddress;
+    let signer:Wallet;
+
+    let sample: SampleProxyConnector;
+
+    it("should deploy contracts", async function () {
+        [owner] = await ethers.getSigners();
+
+        signer = new ethers.Wallet(MockPriceFeed.P_KEY, owner.provider);
+
+        const SampleProxyConnector = await ethers.getContractFactory("SampleProxyConnector");
+        sample = (await SampleProxyConnector.deploy()) as SampleProxyConnector;
+    });
+
+
+    it("should return correct 1st price for one price data set", async function () {
+        const mockPrices = [
+            {symbol: "ETH", value: 10}
+        ];
+
+        sample = WrapperBuilder
+            .mockLite(sample)
+            .using(
+            () => {
+                return {
+                    prices: mockPrices,
+                    timestamp: Date.now()
+                }
+            });
+
+        await sample.initializePriceAware();
+
+        await syncTime(); // recommended for hardhat test
+        await expect(sample.checkPrice(toBytes32("ETH"), 1000000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("ETH"), 9999)).to.be.revertedWith("Wrong price!");
+    });
+
+    it("should return correct prices for two prices data set", async function () {
+        const mockPrices = [
+            {symbol: "ETH", value: 10},
+            {symbol: "AVAX", value: 5}
+        ];
+
+        sample = WrapperBuilder
+            .mockLite(sample)
+            .using(
+                () => {
+                    return {
+                        prices: mockPrices,
+                        timestamp: Date.now()
+                    }
+                });
+
+        await sample.initializePriceAware();
+
+        await syncTime(); // recommended for hardhat test
+        await expect(sample.checkPrice(toBytes32("ETH"), 1000000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("ETH"), 9999)).to.be.revertedWith("Wrong price!");
+
+        await expect(sample.checkPrice(toBytes32("AVAX"), 500000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("AVAX"), 9999)).to.be.revertedWith("Wrong price!");
+    });
+
+    it("should return correct prices for 10 prices data set", async function () {
+        const mockPrices = [
+            {symbol: "ETH", value: 4000},
+            {symbol: "AVAX", value: 5},
+            {symbol: "BTC", value: 100000},
+            {symbol: "LINK", value: 2},
+            {symbol: "UNI", value: 200},
+            {symbol: "FRAX", value: 1},
+            {symbol: "OMG", value: 0.00003},
+            {symbol: "DOGE", value: 2},
+            {symbol: "SOL", value: 11},
+            {symbol: "BNB", value: 31},
+        ];
+
+        sample = WrapperBuilder
+            .mockLite(sample)
+            .using(
+                () => {
+                    return {
+                        prices: mockPrices,
+                        timestamp: Date.now()
+                    }
+                });
+
+        await sample.initializePriceAware();
+
+        await syncTime(); // recommended for hardhat test
+        await expect(sample.checkPrice(toBytes32("ETH"), 400000000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("AVAX"), 500000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("BTC"), 10000000000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("LINK"), 200000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("UNI"), 20000000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("FRAX"), 100000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("OMG"), 3000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("DOGE"), 200000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("SOL"), 1100000000)).not.to.be.reverted;
+        await expect(sample.checkPrice(toBytes32("BNB"), 3100000000)).not.to.be.reverted;
+    });
+
+    it("should return correct prices for a short encoded function", async function () {
+        const mockPrices = [
+            {symbol: "ETH", value: 10}
+        ];
+
+        sample = WrapperBuilder
+            .mockLite(sample)
+            .using(
+                () => {
+                    return {
+                        prices: mockPrices,
+                        timestamp: Date.now()
+                    }
+                });
+
+        await sample.initializePriceAware();
+
+        await syncTime(); // recommended for hardhat test
+        await expect(sample.getPriceShortEncodedFunction(toBytes32("ETH"), 1000000000)).not.to.be.reverted;
+        await expect(sample.getPriceShortEncodedFunction(toBytes32("ETH"), 9999)).to.be.revertedWith("Wrong price!");
+    });
+
+    it("should return correct prices for a long encoded function", async function () {
+        const mockPrices = [
+            {symbol: "ETH", value: 10}
+        ];
+
+        sample = WrapperBuilder
+            .mockLite(sample)
+            .using(
+                () => {
+                    return {
+                        prices: mockPrices,
+                        timestamp: Date.now()
+                    }
+                });
+
+        await sample.initializePriceAware();
+
+        await syncTime(); // recommended for hardhat test
+        await expect(sample.getPriceLongEncodedFunction(toBytes32("ETH"), 1000000000)).not.to.be.reverted;
+        await expect(sample.getPriceLongEncodedFunction(toBytes32("ETH"), 9999)).to.be.revertedWith("Wrong price!");
+    });
+});
+
+


### PR DESCRIPTION
Allows to forward calldata from client-side wrapped contract that doesn't implement PriceAware to the PriceAware type contract.